### PR TITLE
Support/wagtail 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,34 +6,21 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
-    name: |
-      build (Python ${{ matrix.python-version }},
-      Django ${{ matrix.django-version }},
-      Wagtail ${{ matrix.wagtail-version }}),
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2", "4.1", "4.2"]
-        wagtail-version: ["4.1", "4.2", "5.0"]
-        exclude:
-          - python-version: "3.8"
-            django-version: "4.2"
-          - python-version: "3.9"
-            django-version: "4.2"
-          - python-version: "3.10"
-            django-version: "4.2"
-          - python-version: "3.11"
-            django-version: "3.2"
-          - python-version: "3.11"
-            wagtail-version: "4.1"
-          - python-version: "3.11"
-            wagtail-version: "4.2"
-          - django-version: "3.2"
-            wagtail-version: "5.0"
+        python: ["3.8", "3.9", "3.10", "3.11"]
+
     steps:
       - uses: actions/checkout@v3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,13 @@ license_files =
   LICENSE.txt
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 setup_requires =
   setuptools >= 40.6
   pip >= 10
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=3.2, <4.2
-    wagtail>=4.1, <5.0
+    Django>=3.2, <4.3
+    wagtail>=4.1, <5.2
     python-unsplash>=1.1.0, <1.2

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,16 @@ WAGTAIL =
     4.1: wt41
     4.2: wt42
     5.0: wt50
+    5.1: wt51
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{38,39,310}-dj{32,41}-wt{41,42,50}
-    py{311}-dj{41,42}-wt{50}
+    py{38,39,310}-dj{32,41}-wt{41,42,50,51}
+    py311-dj41-wt{41,42,50,51}
+    py311-dj42-wt{50,51}
 
 [testenv]
 description = Unit tests
@@ -42,3 +44,4 @@ deps =
     wt41: wagtail>=4.1,<4.2
     wt42: wagtail>=4.2,<5.0
     wt50: wagtail>=5.0,<5.1
+    wt51: wagtail>=5.1,<5.2


### PR DESCRIPTION
# Wagtail 5.1 update

The only changes here are to update the test matrix and supported versions. The package should work OK with Wagtail v5.1