### PR TITLE
Checks for Wagtail 6.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,17 @@ default_language_version:
   python: python3.12
 repos:
   - repo: https://github.com/python/black
-    rev: 23.1.0
+    rev: 24.4.2
     hooks:
       - id: black
         exclude: migrations/
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
-    rev: 3.8.3
+    rev: 7.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- Add tests for Wagtail 6
+- Drop support for Django < 4.2
+
 ## 1.1.0 (2024-03-11)
 
 - Add tests for Wagtail 5.1+

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,11 @@ license_files =
 [options]
 python_requires = >= 3.8
 setup_requires =
-  setuptools >= 40.6
-  pip >= 10
+  setuptools >= 70.0.0
+  pip >= 24.0
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=3.2
+    Django>=4.2
     wagtail>=5.2
-    python-unsplash>=1.1.0, <1.2
+    python-unsplash>=1.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ license_files =
   LICENSE.txt
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.9
 setup_requires =
   setuptools >= 70.0.0
   pip >= 24.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 testing_extras = [
-    "coverage>=4.5",
+    "coverage>=7.5.2",
 ]
 
 setup(
@@ -27,13 +27,12 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    install_requires=["wagtail>=5.2", "python-unsplash>=1.1.0"],
+    install_requires=["wagtail>=5.2", "python-unsplash>=1.2.5"],
     extras_require={"testing": testing_extras},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Wagtail",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
@@ -31,7 +30,6 @@ install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run --source=wagtailmakeup runtests.py
 
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -9,20 +9,23 @@ python =
 DJANGO =
     4.2: dj42
     5.0: dj50
+    5.1: dj51
 
 WAGTAIL =
     5.2: wt52
     6.0: wt60
     6.1: wt61
     6.2: wt62
+    6.3: wt63
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{38,39,310,311}-dj42-wt{52,60,61,62}
-    py{310,311,312}-dj50-wt{52,60,61,62}
+    py{39,310,311}-dj42-wt{52,60,61,62,63}
+    py{310,311,312}-dj50-wt{52,60,61,62,63}
+    py{310,311,312}-dj51-wt{63}
 
 [testenv]
 description = Unit tests
@@ -38,7 +41,9 @@ basepython =
 deps =
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
     wt52: wagtail>=5.2,<5.3
     wt60: wagtail>=6.0,<6.1
     wt61: wagtail>=6.1,<6.2
     wt62: wagtail>=6.2,<6.3
+    wt63: wagtail>=6.3,<6.4

--- a/tox.ini
+++ b/tox.ini
@@ -8,22 +8,21 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
     4.2: dj42
     5.0: dj50
 
 WAGTAIL =
     5.2: wt52
     6.0: wt60
+    6.1: wt61
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{38,39,310}-dj32-wt52
-    py{38,39,310,311}-dj42-wt{52,60}
-    py{311,312}-dj50-wt{52,60}
+    py{38,39,310,311}-dj42-wt{52,60,61}
+    py{310,311,312}-dj50-wt{52,60,61}
 
 [testenv]
 description = Unit tests
@@ -38,8 +37,8 @@ basepython =
     py312: python3.12
 
 deps =
-    dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
     wt52: wagtail>=5.2,<5.3
     wt60: wagtail>=6.0,<6.1
+    wt61: wagtail>=6.1,<6.2

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,15 @@ WAGTAIL =
     5.2: wt52
     6.0: wt60
     6.1: wt61
+    6.2: wt62
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{38,39,310,311}-dj42-wt{52,60,61}
-    py{310,311,312}-dj50-wt{52,60,61}
+    py{38,39,310,311}-dj42-wt{52,60,61,62}
+    py{310,311,312}-dj50-wt{52,60,61,62}
 
 [testenv]
 description = Unit tests
@@ -42,3 +43,4 @@ deps =
     wt52: wagtail>=5.2,<5.3
     wt60: wagtail>=6.0,<6.1
     wt61: wagtail>=6.1,<6.2
+    wt62: wagtail>=6.2,<6.3

--- a/wagtailmakeup/tests/settings.py
+++ b/wagtailmakeup/tests/settings.py
@@ -47,7 +47,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "wagtail.core.middleware.SiteMiddleware",
 ]
 
 ROOT_URLCONF = "wagtailmakeup.tests.urls"


### PR DESCRIPTION
This pull request includes several updates to dependencies, Python version support, and testing configurations.

The commits from: #27 which also included #26 so they can be closed now.

### Python version support:
* Removed support for Python 3.8 in `.github/workflows/tests.yml`, `tox.ini`, and `setup.cfg`. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL22-R22) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L3-R49) [[3]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L16-R25)

### Dependency updates:
* Updated `black`, `isort`, and `flake8` versions in `.pre-commit-config.yaml`.
* Updated `setuptools` and `pip` versions in `setup.cfg`.
* Updated `coverage` version in `setup.py`.
* Updated `python-unsplash` version in `setup.cfg` and `setup.py`. [[1]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L16-R25) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L30-R38)

### Django and Wagtail support:
* Added support for Django 5.1 and Wagtail 6.x in `tox.ini` and `CHANGELOG.md`. [[1]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L3-R49) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R11)

### Miscellaneous:
* Removed `SiteMiddleware` from `wagtailmakeup/tests/settings.py`.